### PR TITLE
fix: 100ms / 0.1s not accepted as valid for stop_grace_period; chg to 1s

### DIFF
--- a/chapter02/docker-compose.yml
+++ b/chapter02/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - grocery-store
       - opentelemetry-collector
-    stop_grace_period: 100ms
+    stop_grace_period: 1s
   grocery-store:
     image: codeboten/grocery-store:chapter2
     container_name: grocery-store
@@ -25,7 +25,7 @@ services:
     depends_on:
       - legacy-inventory
       - opentelemetry-collector
-    stop_grace_period: 100ms
+    stop_grace_period: 1s
     ports:
       - 5000:5000
     deploy:
@@ -43,7 +43,7 @@ services:
       - cloud-native-observability
     depends_on:
       - opentelemetry-collector
-    stop_grace_period: 100ms
+    stop_grace_period: 1s
     ports:
       - 5001:5001
     deploy:
@@ -85,7 +85,7 @@ services:
       - 4317:4317
       - 13133:13133
       - 8889:8889
-    stop_grace_period: 100ms
+    stop_grace_period: 1s
   loki:
     image: grafana/loki:2.3.0
     container_name: loki


### PR DESCRIPTION
Fix for #16.

The `stop_grace_period` is set to `100ms` which causes an error:

```
ERROR: for opentelemetry-collector  Cannot create container for service opentelemetry-collector: json: cannot unmarshal number 0.1 into Go struct field ContainerConfigWrapper.StopTimeout of type int
```

What seems to be happening is that the 100ms is being converted into 0.1s, but that is not working (fails with the error above trying). Because of this, trying `0.1s` fails as well.

Although this increases the grace period by 10x, setting the value to `1s` allows the container to come up as expected.

Note that I have no idea if this is a change in how docker-compose handles this value, perhaps tied to the recent move to plugin status, since I assume that this did work at one point.
